### PR TITLE
Dev/guma/refactor interval

### DIFF
--- a/src/GShark.Test.XUnit/Core/IntervalTests.cs
+++ b/src/GShark.Test.XUnit/Core/IntervalTests.cs
@@ -42,13 +42,81 @@ namespace GShark.Test.XUnit.Core
         }
 
         [Fact]
-        public void It_Returns_The_Interval_Medium_Value()
+        public void It_Returns_The_Mid_Value_Of_The_Interval()
         {
             Interval interval = new Interval(1.5, 15.3);
 
             double intervalMidVal = interval.Mid;
 
             intervalMidVal.Should().Be(8.4);
+        }
+
+        [Fact]
+        public void It_Returns_True_If_Interval_Is_Decreasing()
+        {
+            //Arrange
+
+            //Act
+            var interval = new Interval(5.5, 0.2);
+
+            //Assert
+            interval.IsDecreasing.Should().Be(true);
+            interval.IsIncreasing.Should().Be(false);
+            interval.IsSingleton.Should().Be(false);
+        }
+        
+        [Fact]
+        public void It_Returns_True_If_Interval_Is_Increasing()
+        {
+            //Arrange
+
+            //Act
+            var interval = new Interval(0.2, 0.5);
+
+            //Assert
+            interval.IsDecreasing.Should().Be(false);
+            interval.IsIncreasing.Should().Be(true);
+            interval.IsSingleton.Should().Be(false);
+        }
+
+        [Fact]
+        public void It_Returns_True_If_Interval_Is_Singleton()
+        {
+            //Arrange
+
+            //Act
+            var interval = new Interval(0.2, 0.2);
+
+            //Assert
+            interval.IsDecreasing.Should().Be(false);
+            interval.IsIncreasing.Should().Be(false);
+            interval.IsSingleton.Should().Be(true);
+        }
+
+        [Fact]
+        public void It_Returns_The_Maximum_Value_In_The_Interval()
+        {
+            //Arrange
+            var expectedMaxValue = 0.5;
+
+            //Act
+            var interval = new Interval(expectedMaxValue, 0.2);
+
+            //Assert
+            interval.Max.Should().Be(0.5);
+        }
+
+        [Fact]
+        public void It_Returns_The_Minimum_Value_In_The_Interval()
+        {
+            //Arrange
+            var expectedMinValue = -0.5;
+
+            //Act
+            var interval = new Interval(expectedMinValue, 0.2);
+
+            //Assert
+            interval.Min.Should().Be(-0.5);
         }
     }
 }

--- a/src/GShark.Test.XUnit/Core/IntervalTests.cs
+++ b/src/GShark.Test.XUnit/Core/IntervalTests.cs
@@ -7,13 +7,13 @@ namespace GShark.Test.XUnit.Core
     public class IntervalTests
     {
         [Fact]
-        public void It_Returns_A_Interval()
+        public void It_Returns_An_Interval()
         {
             Interval interval = new Interval(-10, 20);
 
             interval.Should().NotBeNull();
-            interval.Max.Should().Be(20);
-            interval.Min.Should().Be(-10);
+            interval.T1.Should().Be(20);
+            interval.T0.Should().Be(-10);
         }
 
         [Theory]
@@ -22,7 +22,7 @@ namespace GShark.Test.XUnit.Core
         [InlineData(0.5, 5)]
         [InlineData(0.75, 12.5)]
         [InlineData(1, 20)]
-        public void It_Returns_The_Value_At_The_Give_Normalized_Parameter(double normalizeParam, double valueExpected)
+        public void It_Returns_The_Value_At_The_Given_Normalized_Parameter(double normalizeParam, double valueExpected)
         {
             Interval interval = new Interval(-10, 20);
 

--- a/src/GShark.Test.XUnit/Core/SetsTests.cs
+++ b/src/GShark.Test.XUnit/Core/SetsTests.cs
@@ -97,7 +97,7 @@ namespace GShark.Test.XUnit.Core
             Func<object> resultFunction = () => Sets.Range(maxValue);
             
             // Assert
-            resultFunction.Should().Throw<Exception>().WithMessage("Max value range can not be negative or zero.");
+            resultFunction.Should().Throw<Exception>().WithMessage("T1 value range can not be negative or zero.");
         }
 
         [Theory]

--- a/src/GShark.Test.XUnit/Core/TransformTests.cs
+++ b/src/GShark.Test.XUnit/Core/TransformTests.cs
@@ -139,13 +139,13 @@ namespace GShark.Test.XUnit.Core
             Transform transform = Transform.PlanarProjection(plane);
 
             // Assert
-            transform[0][0].Should().BeApproximately(0.692308, GeoSharpMath.MAXTOLERANCE);
-            transform[0][1].Should().BeApproximately(-0.461538, GeoSharpMath.MAXTOLERANCE);
-            transform[0][3].Should().BeApproximately(1.538462, GeoSharpMath.MAXTOLERANCE);
-            transform[1][0].Should().BeApproximately(-0.461538, GeoSharpMath.MAXTOLERANCE);
-            transform[1][1].Should().BeApproximately(0.307692, GeoSharpMath.MAXTOLERANCE);
-            transform[1][3].Should().BeApproximately(2.307692, GeoSharpMath.MAXTOLERANCE);
-            transform[3][3].Should().BeApproximately(1.0, GeoSharpMath.MAXTOLERANCE);
+            transform[0][0].Should().BeApproximately(0.692308, GeoSharpMath.MAX_TOLERANCE);
+            transform[0][1].Should().BeApproximately(-0.461538, GeoSharpMath.MAX_TOLERANCE);
+            transform[0][3].Should().BeApproximately(1.538462, GeoSharpMath.MAX_TOLERANCE);
+            transform[1][0].Should().BeApproximately(-0.461538, GeoSharpMath.MAX_TOLERANCE);
+            transform[1][1].Should().BeApproximately(0.307692, GeoSharpMath.MAX_TOLERANCE);
+            transform[1][3].Should().BeApproximately(2.307692, GeoSharpMath.MAX_TOLERANCE);
+            transform[3][3].Should().BeApproximately(1.0, GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -160,13 +160,13 @@ namespace GShark.Test.XUnit.Core
             Transform transform = Transform.PlaneToPlane(Plane.PlaneXY, plane);
 
             // Assert
-            transform[0][0].Should().BeApproximately(-0.832050, GeoSharpMath.MAXTOLERANCE);
-            transform[0][2].Should().BeApproximately(-0.554700, GeoSharpMath.MAXTOLERANCE);
-            transform[0][3].Should().BeApproximately(5.0, GeoSharpMath.MAXTOLERANCE);
-            transform[1][0].Should().BeApproximately(0.554700, GeoSharpMath.MAXTOLERANCE);
-            transform[1][2].Should().BeApproximately(-0.832050, GeoSharpMath.MAXTOLERANCE);
-            transform[2][1].Should().BeApproximately(-1.0, GeoSharpMath.MAXTOLERANCE);
-            transform[3][3].Should().BeApproximately(1.0, GeoSharpMath.MAXTOLERANCE);
+            transform[0][0].Should().BeApproximately(-0.832050, GeoSharpMath.MAX_TOLERANCE);
+            transform[0][2].Should().BeApproximately(-0.554700, GeoSharpMath.MAX_TOLERANCE);
+            transform[0][3].Should().BeApproximately(5.0, GeoSharpMath.MAX_TOLERANCE);
+            transform[1][0].Should().BeApproximately(0.554700, GeoSharpMath.MAX_TOLERANCE);
+            transform[1][2].Should().BeApproximately(-0.832050, GeoSharpMath.MAX_TOLERANCE);
+            transform[2][1].Should().BeApproximately(-1.0, GeoSharpMath.MAX_TOLERANCE);
+            transform[3][3].Should().BeApproximately(1.0, GeoSharpMath.MAX_TOLERANCE);
         }
     }
 }

--- a/src/GShark.Test.XUnit/Core/TrigonometryTests.cs
+++ b/src/GShark.Test.XUnit/Core/TrigonometryTests.cs
@@ -32,7 +32,7 @@ namespace GShark.Test.XUnit.Core
             Vector3 pt3 = new Vector3 { 51.299, 37.950, 0.0 };
 
             // Assert
-            Trigonometry.AreThreePointsCollinear(pt1, pt2, pt3, GeoSharpMath.MINTOLERANCE).Should().BeTrue();
+            Trigonometry.AreThreePointsCollinear(pt1, pt2, pt3, GeoSharpMath.MIN_TOLERANCE).Should().BeTrue();
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace GShark.Test.XUnit.Core
             Vector3 pt3 = new Vector3 { 51.299, 37.950, 0.0 };
 
             // Assert
-            Trigonometry.AreThreePointsCollinear(pt1, pt2, pt3, GeoSharpMath.MINTOLERANCE).Should().BeFalse();
+            Trigonometry.AreThreePointsCollinear(pt1, pt2, pt3, GeoSharpMath.MIN_TOLERANCE).Should().BeFalse();
         }
 
         [Theory]
@@ -63,7 +63,7 @@ namespace GShark.Test.XUnit.Core
             (double tValue, Vector3 pt) closestPt = Trigonometry.ClosestPointToSegment(ptToCheck.ToVector(), pt0, pt1, 0, 1);
 
             // Assert
-            closestPt.tValue.Should().BeApproximately(tValExpected, GeoSharpMath.MAXTOLERANCE);
+            closestPt.tValue.Should().BeApproximately(tValExpected, GeoSharpMath.MAX_TOLERANCE);
             closestPt.pt.Should().BeEquivalentTo(ptExpected.ToVector());
         }
     }

--- a/src/GShark.Test.XUnit/Geometry/ArcTests.cs
+++ b/src/GShark.Test.XUnit/Geometry/ArcTests.cs
@@ -38,10 +38,10 @@ namespace GShark.Test.XUnit.Geometry
 
             // Assert
             arc.Should().NotBeNull();
-            arc.Length.Should().BeApproximately(10.471976, GeoSharpMath.MAXTOLERANCE);
+            arc.Length.Should().BeApproximately(10.471976, GeoSharpMath.MAX_TOLERANCE);
             arc.Center.Should().BeEquivalentTo(Plane.PlaneXY.Origin);
             arc.Radius.Should().Be(15);
-            arc.Angle.Should().BeApproximately(0.698132, GeoSharpMath.MAXTOLERANCE);
+            arc.Angle.Should().BeApproximately(0.698132, GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -51,9 +51,9 @@ namespace GShark.Test.XUnit.Geometry
             Arc arc = _exampleArc3D;
 
             // Assert
-            arc.Length.Should().BeApproximately(71.333203, GeoSharpMath.MAXTOLERANCE);
-            arc.Radius.Should().BeApproximately(16.47719, GeoSharpMath.MAXTOLERANCE);
-            GeoSharpMath.ToDegrees(arc.Angle).Should().BeApproximately(248.045414, GeoSharpMath.MAXTOLERANCE);
+            arc.Length.Should().BeApproximately(71.333203, GeoSharpMath.MAX_TOLERANCE);
+            arc.Radius.Should().BeApproximately(16.47719, GeoSharpMath.MAX_TOLERANCE);
+            GeoSharpMath.ToDegrees(arc.Angle).Should().BeApproximately(248.045414, GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace GShark.Test.XUnit.Geometry
             // Assert
             arc.StartPoint.IsEqualRoundingDecimal(pt1, 6).Should().BeTrue();
             arc.EndPoint.IsEqualRoundingDecimal(pt2, 6).Should().BeTrue();
-            arc.Radius.Should().BeApproximately(12.247449, GeoSharpMath.MAXTOLERANCE);
+            arc.Radius.Should().BeApproximately(12.247449, GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]

--- a/src/GShark.Test.XUnit/Geometry/BoundingBoxTests.cs
+++ b/src/GShark.Test.XUnit/Geometry/BoundingBoxTests.cs
@@ -45,8 +45,8 @@ namespace GShark.Test.XUnit.Geometry
             // Assert
             _testOutput.WriteLine(bBox.ToString());
             bBox.Should().NotBeNull();
-            bBox.Min.DistanceTo(expectedMin).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
-            bBox.Max.DistanceTo(expectedMax).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            bBox.Min.DistanceTo(expectedMin).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
+            bBox.Max.DistanceTo(expectedMax).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]

--- a/src/GShark.Test.XUnit/Geometry/LineTests.cs
+++ b/src/GShark.Test.XUnit/Geometry/LineTests.cs
@@ -174,7 +174,7 @@ namespace GShark.Test.XUnit.Geometry
             double parameter = _exampleLine.ClosestParameter(pt);
 
             // Assert
-            parameter.Should().BeApproximately(expectedParam, GeoSharpMath.MAXTOLERANCE);
+            parameter.Should().BeApproximately(expectedParam, GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace GShark.Test.XUnit.Geometry
             Line extendedLine = _exampleLine.Extend(0, -5);
 
             // Assert
-            extendedLine.Length.Should().BeApproximately(13.027756, GeoSharpMath.MAXTOLERANCE);
+            extendedLine.Length.Should().BeApproximately(13.027756, GeoSharpMath.MAX_TOLERANCE);
             extendedLine.Start.Should().BeEquivalentTo(_exampleLine.Start);
         }
 

--- a/src/GShark.Test.XUnit/Geometry/NurbsCurveTests.cs
+++ b/src/GShark.Test.XUnit/Geometry/NurbsCurveTests.cs
@@ -109,11 +109,11 @@ namespace GShark.Test.XUnit.Geometry
             BoundingBox bBox1 = crv1.BoundingBox;
 
             // Assert
-            bBox0.Max.DistanceTo(expectedPtMax0).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
-            bBox0.Min.DistanceTo(expectedPtMin0).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            bBox0.Max.DistanceTo(expectedPtMax0).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
+            bBox0.Min.DistanceTo(expectedPtMin0).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
 
-            bBox1.Max.DistanceTo(expectedPtMax1).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
-            bBox1.Min.DistanceTo(expectedPtMin1).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            bBox1.Max.DistanceTo(expectedPtMax1).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
+            bBox1.Min.DistanceTo(expectedPtMin1).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -134,11 +134,11 @@ namespace GShark.Test.XUnit.Geometry
             BoundingBox bBox1 = crv1.BoundingBox;
 
             // Assert
-            bBox0.Max.DistanceTo(expectedPtMax0).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
-            bBox0.Min.DistanceTo(expectedPtMin0).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            bBox0.Max.DistanceTo(expectedPtMax0).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
+            bBox0.Min.DistanceTo(expectedPtMin0).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
 
-            bBox1.Max.DistanceTo(expectedPtMax1).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
-            bBox1.Min.DistanceTo(expectedPtMin1).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            bBox1.Max.DistanceTo(expectedPtMax1).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
+            bBox1.Min.DistanceTo(expectedPtMin1).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -203,8 +203,8 @@ namespace GShark.Test.XUnit.Geometry
             var curveDomain = NurbsCurveCollection.NurbsCurveExample().Domain;
 
             // Assert
-            curveDomain.Min.Should().Be(NurbsCurveCollection.NurbsCurveExample().Knots.First());
-            curveDomain.Max.Should().Be(NurbsCurveCollection.NurbsCurveExample().Knots.Last());
+            curveDomain.T0.Should().Be(NurbsCurveCollection.NurbsCurveExample().Knots.First());
+            curveDomain.T1.Should().Be(NurbsCurveCollection.NurbsCurveExample().Knots.Last());
         }
 
         [Fact]

--- a/src/GShark.Test.XUnit/Geometry/PlaneTests.cs
+++ b/src/GShark.Test.XUnit/Geometry/PlaneTests.cs
@@ -83,7 +83,7 @@ namespace GShark.Test.XUnit.Geometry
 
             // Assert
             closestPt.IsEqualRoundingDecimal(new Vector3 {3.153846, 1.230769, 3}, 6).Should().BeTrue();
-            System.Math.Abs(distance).Should().BeApproximately(expectedDistance, GeoSharpMath.MAXTOLERANCE);
+            System.Math.Abs(distance).Should().BeApproximately(expectedDistance, GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]

--- a/src/GShark.Test.XUnit/Geometry/PolygonTests.cs
+++ b/src/GShark.Test.XUnit/Geometry/PolygonTests.cs
@@ -85,7 +85,7 @@ namespace GShark.Test.XUnit.Geometry
 
             // Assert
             poly2DArea.Should().Be(45);
-            poly3DArea.Should().BeApproximately(480.580633, GeoSharpMath.MINTOLERANCE);
+            poly3DArea.Should().BeApproximately(480.580633, GeoSharpMath.MIN_TOLERANCE);
         }
 
         [Fact]
@@ -122,8 +122,8 @@ namespace GShark.Test.XUnit.Geometry
             Vector3 poly3DCentroid = poly3D.CentroidByArea;
 
             // Assert
-            poly2DCentroid.DistanceTo(centroid2DExpected).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
-            poly3DCentroid.DistanceTo(centroid3DExpected).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            poly2DCentroid.DistanceTo(centroid2DExpected).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
+            poly3DCentroid.DistanceTo(centroid3DExpected).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]

--- a/src/GShark.Test.XUnit/Geometry/PolylineTests.cs
+++ b/src/GShark.Test.XUnit/Geometry/PolylineTests.cs
@@ -27,8 +27,6 @@ namespace GShark.Test.XUnit.Geometry
                 new Vector3 {30, 10, 0}, 
                 new Vector3 {45, 12.5, 0}
             };
-
-            Polyline poly = new Polyline(_examplePts);
             #endregion
         }
 

--- a/src/GShark.Test.XUnit/Geometry/PolylineTests.cs
+++ b/src/GShark.Test.XUnit/Geometry/PolylineTests.cs
@@ -93,7 +93,7 @@ namespace GShark.Test.XUnit.Geometry
             double length = polyline.Length();
 
             // Assert
-            length.Should().BeApproximately(expectedLength, GeoSharpMath.MAXTOLERANCE);
+            length.Should().BeApproximately(expectedLength, GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace GShark.Test.XUnit.Geometry
             // Assert
             segments.Length.Should().Be(expectedNumberOfSegments);
             segments[1].Length.Should().Be(segments[2].Length)
-                .And.BeApproximately(expectedSegmentLength, GeoSharpMath.MAXTOLERANCE);
+                .And.BeApproximately(expectedSegmentLength, GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Theory]
@@ -145,7 +145,7 @@ namespace GShark.Test.XUnit.Geometry
             double param = polyline.ClosestParameter(closestPt);
 
             // Assert
-            param.Should().BeApproximately(expextedParam, GeoSharpMath.MAXTOLERANCE);
+            param.Should().BeApproximately(expextedParam, GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Theory]
@@ -193,7 +193,7 @@ namespace GShark.Test.XUnit.Geometry
             Line segment = polyline.SegmentAt(index);
 
             // Assert
-            segment.Length.Should().BeApproximately(segmentLength, GeoSharpMath.MAXTOLERANCE);
+            segment.Length.Should().BeApproximately(segmentLength, GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Theory]
@@ -226,7 +226,7 @@ namespace GShark.Test.XUnit.Geometry
 
             // Assert
             double[] lengths = polyline.Select((pt, i) => pt.DistanceTo(transformedPoly[i])).ToArray();
-            lengths.Select((val, i) => val.Should().BeApproximately(distanceExpected[i], GeoSharpMath.MAXTOLERANCE));
+            lengths.Select((val, i) => val.Should().BeApproximately(distanceExpected[i], GeoSharpMath.MAX_TOLERANCE));
         }
 
         [Fact]

--- a/src/GShark.Test.XUnit/Operation/AnalyzeTests.cs
+++ b/src/GShark.Test.XUnit/Operation/AnalyzeTests.cs
@@ -43,8 +43,8 @@ namespace GShark.Test.XUnit.Operation
             double curveLength2 = Analyze.BezierCurveLength(curve2, 4);
 
             // Assert
-            curveLength1.Should().BeApproximately(expectedLength, GeoSharpMath.MAXTOLERANCE);
-            curveLength2.Should().BeApproximately(expectedLength, GeoSharpMath.MAXTOLERANCE);
+            curveLength1.Should().BeApproximately(expectedLength, GeoSharpMath.MAX_TOLERANCE);
+            curveLength2.Should().BeApproximately(expectedLength, GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -61,13 +61,13 @@ namespace GShark.Test.XUnit.Operation
             for (int i = 0; i < steps + 1; i++)
             {
                 // Act
-                double t = Analyze.BezierCurveParamAtLength(curve, sumLengths, GeoSharpMath.MAXTOLERANCE);
+                double t = Analyze.BezierCurveParamAtLength(curve, sumLengths, GeoSharpMath.MAX_TOLERANCE);
 
                 double segmentLength = Analyze.BezierCurveLength(curve, t);
 
                 // Assert
-                t.Should().BeApproximately(tValuesExpected[i], GeoSharpMath.MINTOLERANCE);
-                segmentLength.Should().BeApproximately(sumLengths, GeoSharpMath.MINTOLERANCE);
+                t.Should().BeApproximately(tValuesExpected[i], GeoSharpMath.MIN_TOLERANCE);
+                segmentLength.Should().BeApproximately(sumLengths, GeoSharpMath.MIN_TOLERANCE);
 
                 sumLengths += length;
             }
@@ -108,10 +108,10 @@ namespace GShark.Test.XUnit.Operation
             Vector3 pt = LinearAlgebra.PointDehomogenizer(ptHomogenized);
 
             // Assert
-            t.Should().BeApproximately(tValExpected, GeoSharpMath.MAXTOLERANCE);
+            t.Should().BeApproximately(tValExpected, GeoSharpMath.MAX_TOLERANCE);
             // https://stackoverflow.com/questions/36782975/fluent-assertions-approximately-compare-a-classes-properties
             pt.Should().BeEquivalentTo(ptExpected.ToVector(), options => options
-                .Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, GeoSharpMath.MAXTOLERANCE))
+                .Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, GeoSharpMath.MAX_TOLERANCE))
                 .WhenTypeIs<double>());
         }
 

--- a/src/GShark.Test.XUnit/Operation/DivideTests.cs
+++ b/src/GShark.Test.XUnit/Operation/DivideTests.cs
@@ -46,13 +46,13 @@ namespace GShark.Test.XUnit.Operation
             for (int i = 0; i < degree + 1; i++)
             {
                 int d = curves[0].Knots.Count - (degree + 1);
-                curves[0].Knots[d + i].Should().BeApproximately(parameter, GeoSharpMath.MAXTOLERANCE);
+                curves[0].Knots[d + i].Should().BeApproximately(parameter, GeoSharpMath.MAX_TOLERANCE);
             }
 
             for (int i = 0; i < degree + 1; i++)
             {
                 int d = 0;
-                curves[1].Knots[d + i].Should().BeApproximately(parameter, GeoSharpMath.MAXTOLERANCE);
+                curves[1].Knots[d + i].Should().BeApproximately(parameter, GeoSharpMath.MAX_TOLERANCE);
             }
         }
 
@@ -70,7 +70,7 @@ namespace GShark.Test.XUnit.Operation
             // Assert
             divisions.tValues.Count.Should().Be(divisions.lengths.Count).And.Be(steps + 1);
             for (int i = 0; i < steps; i++)
-                divisions.tValues[i].Should().BeApproximately(tValuesExpected[i], GeoSharpMath.MINTOLERANCE);
+                divisions.tValues[i].Should().BeApproximately(tValuesExpected[i], GeoSharpMath.MIN_TOLERANCE);
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace GShark.Test.XUnit.Operation
             // Assert
             divisions.tValues.Count.Should().Be(divisions.lengths.Count).And.Be(steps + 1);
             for (int i = 0; i < steps; i++)
-                divisions.tValues[i].Should().BeApproximately(tValuesExpected[i], GeoSharpMath.MINTOLERANCE);
+                divisions.tValues[i].Should().BeApproximately(tValuesExpected[i], GeoSharpMath.MIN_TOLERANCE);
         }
     }
 }

--- a/src/GShark.Test.XUnit/Operation/EvaluationTests.cs
+++ b/src/GShark.Test.XUnit/Operation/EvaluationTests.cs
@@ -325,17 +325,17 @@ namespace GShark.Test.XUnit.Operation
             List<Vector3> resultToCheck = Evaluation.DerivativeBasisFunctionsGivenNI(span, parameter, degree, order, knots);
 
             // Assert
-            resultToCheck[0][0].Should().BeApproximately(expectedResult[0, 0], GeoSharpMath.MAXTOLERANCE);
-            resultToCheck[0][1].Should().BeApproximately(expectedResult[0, 1], GeoSharpMath.MAXTOLERANCE);
-            resultToCheck[0][2].Should().BeApproximately(expectedResult[0, 2], GeoSharpMath.MAXTOLERANCE);
+            resultToCheck[0][0].Should().BeApproximately(expectedResult[0, 0], GeoSharpMath.MAX_TOLERANCE);
+            resultToCheck[0][1].Should().BeApproximately(expectedResult[0, 1], GeoSharpMath.MAX_TOLERANCE);
+            resultToCheck[0][2].Should().BeApproximately(expectedResult[0, 2], GeoSharpMath.MAX_TOLERANCE);
 
-            resultToCheck[1][0].Should().BeApproximately(expectedResult[1, 0], GeoSharpMath.MAXTOLERANCE);
-            resultToCheck[1][1].Should().BeApproximately(expectedResult[1, 1], GeoSharpMath.MAXTOLERANCE);
-            resultToCheck[1][2].Should().BeApproximately(expectedResult[1, 2], GeoSharpMath.MAXTOLERANCE);
+            resultToCheck[1][0].Should().BeApproximately(expectedResult[1, 0], GeoSharpMath.MAX_TOLERANCE);
+            resultToCheck[1][1].Should().BeApproximately(expectedResult[1, 1], GeoSharpMath.MAX_TOLERANCE);
+            resultToCheck[1][2].Should().BeApproximately(expectedResult[1, 2], GeoSharpMath.MAX_TOLERANCE);
 
-            resultToCheck[2][0].Should().BeApproximately(expectedResult[2, 0], GeoSharpMath.MAXTOLERANCE);
-            resultToCheck[2][1].Should().BeApproximately(expectedResult[2, 1], GeoSharpMath.MAXTOLERANCE);
-            resultToCheck[2][2].Should().BeApproximately(expectedResult[2, 2], GeoSharpMath.MAXTOLERANCE);
+            resultToCheck[2][0].Should().BeApproximately(expectedResult[2, 0], GeoSharpMath.MAX_TOLERANCE);
+            resultToCheck[2][1].Should().BeApproximately(expectedResult[2, 1], GeoSharpMath.MAX_TOLERANCE);
+            resultToCheck[2][2].Should().BeApproximately(expectedResult[2, 2], GeoSharpMath.MAX_TOLERANCE);
 
             resultToCheck.Count.Should().Be(order + 1);
             resultToCheck[0].Count.Should().Be(degree + 1);

--- a/src/GShark.Test.XUnit/Operation/FittingTests.cs
+++ b/src/GShark.Test.XUnit/Operation/FittingTests.cs
@@ -37,13 +37,13 @@ namespace GShark.Test.XUnit.Operation
 
             // Assert
             crv.Degree.Should().Be(degree);
-            crv.ControlPoints[0].DistanceTo(pts[0]).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
-            crv.ControlPoints[^1].DistanceTo(pts[^1]).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            crv.ControlPoints[0].DistanceTo(pts[0]).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
+            crv.ControlPoints[^1].DistanceTo(pts[^1]).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
 
             foreach (Vector3 pt in pts)
             {
                 Vector3 closedPt = crv.ClosestPt(pt);
-                closedPt.DistanceTo(pt).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+                closedPt.DistanceTo(pt).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
             }
         }
 
@@ -60,8 +60,8 @@ namespace GShark.Test.XUnit.Operation
             NurbsCurve crv = Fitting.InterpolatedCurve(pts, 2, v1, v2);
 
             // Assert
-            crv.ControlPoints[0].DistanceTo(pts[0]).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
-            crv.ControlPoints[^1].DistanceTo(pts[^1]).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            crv.ControlPoints[0].DistanceTo(pts[0]).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
+            crv.ControlPoints[^1].DistanceTo(pts[^1]).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
 
             foreach (var crvControlPoint in crv.ControlPoints)
             {
@@ -71,7 +71,7 @@ namespace GShark.Test.XUnit.Operation
             foreach (Vector3 pt in pts)
             {
                 Vector3 closedPt = crv.ClosestPt(pt);
-                closedPt.DistanceTo(pt).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+                closedPt.DistanceTo(pt).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
             }
         }
 

--- a/src/GShark.Test.XUnit/Operation/IntersectionTests.cs
+++ b/src/GShark.Test.XUnit/Operation/IntersectionTests.cs
@@ -261,12 +261,12 @@ namespace GShark.Test.XUnit.Operation
             NurbsCurve crv1 = new NurbsCurve(crvDegree1, crvKnots1, crvCtrPts1);
 
             // Act
-            List<CurvesIntersectionResult> intersection = Intersect.CurveCurve(crv0, crv1, GeoSharpMath.MAXTOLERANCE);
+            List<CurvesIntersectionResult> intersection = Intersect.CurveCurve(crv0, crv1, GeoSharpMath.MAX_TOLERANCE);
 
             // Assert
             intersection.Count.Should().Be(1);
-            intersection[0].T0.Should().BeApproximately(0.25, GeoSharpMath.MAXTOLERANCE);
-            intersection[0].T1.Should().BeApproximately(0.25, GeoSharpMath.MAXTOLERANCE);
+            intersection[0].T0.Should().BeApproximately(0.25, GeoSharpMath.MAX_TOLERANCE);
+            intersection[0].T1.Should().BeApproximately(0.25, GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -288,7 +288,7 @@ namespace GShark.Test.XUnit.Operation
             // Assert
             _testOutput.WriteLine(intersection[0].ToString());
             intersection.Count.Should().Be(1);
-            intersection[0].Pt0.DistanceTo(intersection[0].Pt1).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            intersection[0].Pt0.DistanceTo(intersection[0].Pt1).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -312,7 +312,7 @@ namespace GShark.Test.XUnit.Operation
             // Assert
             _testOutput.WriteLine(intersection[0].ToString());
             intersection.Count.Should().Be(1);
-            intersection[0].Pt0.DistanceTo(intersection[0].Pt1).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            intersection[0].Pt0.DistanceTo(intersection[0].Pt1).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -344,7 +344,7 @@ namespace GShark.Test.XUnit.Operation
             foreach (CurvesIntersectionResult intersection in intersections)
             {
                 _testOutput.WriteLine(intersection.ToString());
-                intersection.Pt0.DistanceTo(intersection.Pt1).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+                intersection.Pt0.DistanceTo(intersection.Pt1).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
             }
         }
 
@@ -377,7 +377,7 @@ namespace GShark.Test.XUnit.Operation
             foreach (CurvesIntersectionResult intersection in intersections)
             {
                 _testOutput.WriteLine(intersection.ToString());
-                intersection.Pt0.DistanceTo(intersection.Pt1).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+                intersection.Pt0.DistanceTo(intersection.Pt1).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
             }
         }
 
@@ -402,7 +402,7 @@ namespace GShark.Test.XUnit.Operation
             // Assert
             _testOutput.WriteLine(intersections[0].ToString());
             intersections.Count.Should().Be(1);
-            intersections[0].Point.DistanceTo(ptOnPlane).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            intersections[0].Point.DistanceTo(ptOnPlane).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -430,7 +430,7 @@ namespace GShark.Test.XUnit.Operation
             {
                 _testOutput.WriteLine(curveIntersectionResult.ToString());
                 Vector3 ptOnPlane = pl.PointAt(curveIntersectionResult.Uv[0], curveIntersectionResult.Uv[1]);
-                curveIntersectionResult.Point.DistanceTo(ptOnPlane).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+                curveIntersectionResult.Point.DistanceTo(ptOnPlane).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
             }
         }
 
@@ -454,7 +454,7 @@ namespace GShark.Test.XUnit.Operation
             // Assert
             _testOutput.WriteLine(intersections[0].ToString());
             intersections.Count.Should().Be(1);
-            intersections[0].Pt0.DistanceTo(ptAt).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            intersections[0].Pt0.DistanceTo(ptAt).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -479,7 +479,7 @@ namespace GShark.Test.XUnit.Operation
             {
                 _testOutput.WriteLine(curveIntersectionResult.ToString());
                 Vector3 ptAt = crv.PointAt(curveIntersectionResult.T1);
-                curveIntersectionResult.Pt0.DistanceTo(ptAt).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+                curveIntersectionResult.Pt0.DistanceTo(ptAt).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
             }
         }
     }

--- a/src/GShark.Test.XUnit/Operation/ModifyTests.cs
+++ b/src/GShark.Test.XUnit/Operation/ModifyTests.cs
@@ -56,9 +56,9 @@ namespace GShark.Test.XUnit.Operation
             Vector3 p0 = curve.PointAt(2.5);
             Vector3 p1 = curveAfterRefine.PointAt(2.5);
 
-            p0[0].Should().BeApproximately(p1[0], GeoSharpMath.MAXTOLERANCE);
-            p0[1].Should().BeApproximately(p1[1], GeoSharpMath.MAXTOLERANCE);
-            p0[2].Should().BeApproximately(p1[2], GeoSharpMath.MAXTOLERANCE);
+            p0[0].Should().BeApproximately(p1[0], GeoSharpMath.MAX_TOLERANCE);
+            p0[1].Should().BeApproximately(p1[1], GeoSharpMath.MAX_TOLERANCE);
+            p0[2].Should().BeApproximately(p1[2], GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace GShark.Test.XUnit.Operation
 
                 double pt0_pt1 = (pt0 - pt1).Length();
 
-                pt0_pt1.Should().BeApproximately(0.0, GeoSharpMath.MAXTOLERANCE);
+                pt0_pt1.Should().BeApproximately(0.0, GeoSharpMath.MAX_TOLERANCE);
             }
         }
 
@@ -119,7 +119,7 @@ namespace GShark.Test.XUnit.Operation
 
                 double pt0_pt1 = (pt0 - pt1).Length();
 
-                pt0_pt1.Should().BeApproximately(0.0, GeoSharpMath.MAXTOLERANCE);
+                pt0_pt1.Should().BeApproximately(0.0, GeoSharpMath.MAX_TOLERANCE);
             }
         }
 

--- a/src/GShark.Test.XUnit/Operation/OffsetTests.cs
+++ b/src/GShark.Test.XUnit/Operation/OffsetTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Collections.Generic;
+using FluentAssertions;
 using GShark.Core;
 using GShark.Geometry;
 using GShark.Geometry.Interfaces;
@@ -12,7 +13,6 @@ namespace GShark.Test.XUnit.Operation
     public class OffsetTests
     {
         private readonly ITestOutputHelper _testOutput;
-
         public OffsetTests(ITestOutputHelper testOutput)
         {
             _testOutput = testOutput;
@@ -51,7 +51,14 @@ namespace GShark.Test.XUnit.Operation
         public void Returns_The_Offset_Of_A_Open_Polyline()
         {
             // Arrange
-            Polyline pl = new Polyline(PolylineTests.ExamplePts);
+            Polyline pl = new Polyline(new[]
+            {
+                new Vector3 {5, 0, 0},
+                new Vector3 {15, 15, 0},
+                new Vector3 {20, 5, 0},
+                new Vector3 {30, 10, 0},
+                new Vector3 {45, 12.5, 0}
+            });
             double offset = 5;
 
             // Act

--- a/src/GShark.Test.XUnit/Operation/OffsetTests.cs
+++ b/src/GShark.Test.XUnit/Operation/OffsetTests.cs
@@ -29,7 +29,7 @@ namespace GShark.Test.XUnit.Operation
             Line offsetResult = Offset.Line(ln, offset, Plane.PlaneXY);
 
             // Assert
-            (offsetResult.Start.DistanceTo(ln.Start) - offset).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            (offsetResult.Start.DistanceTo(ln.Start) - offset).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -65,8 +65,8 @@ namespace GShark.Test.XUnit.Operation
             Polyline offsetResult = Offset.Polyline(pl, offset, Plane.PlaneXY);
 
             // Assert
-            (offsetResult[0].DistanceTo(pl[0]) - offset).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
-            (offsetResult[^1].DistanceTo(pl[^1]) - offset).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            (offsetResult[0].DistanceTo(pl[0]) - offset).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
+            (offsetResult[^1].DistanceTo(pl[^1]) - offset).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace GShark.Test.XUnit.Operation
             offsetResult[0].DistanceTo(offsetResult[^1]).Should().Be(0.0);
             Vector3 pt = offsetResult.PointAt(0.5);
             Vector3 closestPt = pl.ClosestPt(pt);
-            pt.DistanceTo(closestPt).Should().BeApproximately(offset, GeoSharpMath.MINTOLERANCE);
+            pt.DistanceTo(closestPt).Should().BeApproximately(offset, GeoSharpMath.MIN_TOLERANCE);
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace GShark.Test.XUnit.Operation
             {
                 Vector3 pt = offsetResult.PointAt(i);
                 Vector3 closestPt = crv.ClosestPt(pt);
-                pt.DistanceTo(closestPt).Should().BeApproximately(offset, GeoSharpMath.MINTOLERANCE);
+                pt.DistanceTo(closestPt).Should().BeApproximately(offset, GeoSharpMath.MIN_TOLERANCE);
             }
         }
     }

--- a/src/GShark.Test.XUnit/Operation/TessellationTests.cs
+++ b/src/GShark.Test.XUnit/Operation/TessellationTests.cs
@@ -107,8 +107,8 @@ namespace GShark.Test.XUnit.Operation
 
             // Arrange
             result.pts.Count.Should().Be(result.tValues.Count).And.Be(2);
-            result.pts[0].DistanceTo(p1).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
-            result.pts[1].DistanceTo(p2).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            result.pts[0].DistanceTo(p1).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
+            result.pts[1].DistanceTo(p2).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]
@@ -128,8 +128,8 @@ namespace GShark.Test.XUnit.Operation
 
             // Arrange
             result.pts.Count.Should().Be(result.tValues.Count).And.Be(5);
-            result.pts[0].DistanceTo(p1).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
-            result.pts[^1].DistanceTo(p5).Should().BeLessThan(GeoSharpMath.MAXTOLERANCE);
+            result.pts[0].DistanceTo(p1).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
+            result.pts[^1].DistanceTo(p5).Should().BeLessThan(GeoSharpMath.MAX_TOLERANCE);
         }
 
         [Fact]

--- a/src/GShark.sln.DotSettings
+++ b/src/GShark.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Polyline/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/GShark/Core/GeoSharpMath.cs
+++ b/src/GShark/Core/GeoSharpMath.cs
@@ -11,12 +11,12 @@ namespace GShark.Core
         /// <summary>
         /// The default euclidean distance that identifies whether two points are coincident.
         /// </summary>
-        public static double MINTOLERANCE => 1e-3;
+        public static double MIN_TOLERANCE => 1e-3;
 
         /// <summary>
         /// The default euclidean distance that identifies whether two points are coincident.
         /// </summary>
-        public static double MAXTOLERANCE => 1e-6;
+        public static double MAX_TOLERANCE => 1e-6;
 
         /// <summary>
         /// The minimum value to determine whether two floating point numbers are the same.
@@ -26,19 +26,19 @@ namespace GShark.Core
         /// <summary>
         /// The value of an unset object.
         /// </summary>
-        public static double UNSETVALUE => -1.23432101234321E+308;
+        public static double UNSET_VALUE => -1.23432101234321E+308;
 
         /// <summary>
         /// Represents the default angle tolerance, used when no other values are provided.
         /// This is one degree, expressed in radians.
         /// </summary>
-        public static double ANGLETOLERANCE => 0.0174532925199433;
+        public static double ANGLE_TOLERANCE => 0.0174532925199433;
 
         /// <summary>
         /// Converts degrees to radians.
         /// </summary>
-        /// <param name="degrees">Value degrees.</param>
-        /// <returns>The radians value.</returns>
+        /// <param name="degrees">Value in degrees.</param>
+        /// <returns>The value in radians.</returns>
         public static double ToRadians(double degrees)
         {
             return degrees * (Math.PI / 180.0);
@@ -55,7 +55,7 @@ namespace GShark.Core
         }
 
         /// <summary>
-        /// Checks if it is a valid double.
+        /// Returns true if the double value is valid.
         /// </summary>
         /// <param name="x">Double value.</param>
         /// <returns>True if it is valid.</returns>
@@ -65,39 +65,39 @@ namespace GShark.Core
         }
 
         /// <summary>
-        /// Remaps a value into a new numerical range.
+        /// Remaps a value into a new numerical target range given a source range.
         /// </summary>
         /// <param name="value">Value to remap.</param>
-        /// <param name="source">Numerical interval of the value.</param>
-        /// <param name="target">Numerical interval into the value will be remapped.</param>
+        /// <param name="source">Source range.</param>
+        /// <param name="target">Target range.</param>
         /// <returns>Remapped value.</returns>
         public static double RemapValue(double value, Interval source, Interval target)
         {
-            return target.Min + (value - source.Min) * (target.Max - target.Min) / (source.Max - source.Min);
+            return target.T0 + (value - source.T0) * (target.T1 - target.T0) / (source.T1 - source.T0);
         }
 
         /// <summary>
         /// Reduces the noise from the input.
         /// </summary>
-        /// <param name="sinAngle">Sin angle value.</param>
+        /// <param name="sinAngle">Sin angle value.</param> //ToDo Specify whether the parameters are in degrees or radians.
         /// <param name="cosAngle">Cos angle value.</param>
         internal static void KillNoise(ref double sinAngle, ref double cosAngle)
         {
-            if (Math.Abs(sinAngle) >= 1.0 - GeoSharpMath.MAXTOLERANCE &&
-                Math.Abs(cosAngle) <= GeoSharpMath.MAXTOLERANCE)
+            if (Math.Abs(sinAngle) >= 1.0 - GeoSharpMath.MAX_TOLERANCE &&
+                Math.Abs(cosAngle) <= GeoSharpMath.MAX_TOLERANCE)
             {
                 cosAngle = 0.0;
                 sinAngle = (sinAngle < 0.0) ? -1.0 : 1.0;
             }
 
-            if (Math.Abs(cosAngle) >= 1.0 - GeoSharpMath.MAXTOLERANCE &&
-                Math.Abs(sinAngle) <= GeoSharpMath.MAXTOLERANCE)
+            if (Math.Abs(cosAngle) >= 1.0 - GeoSharpMath.MAX_TOLERANCE &&
+                Math.Abs(sinAngle) <= GeoSharpMath.MAX_TOLERANCE)
             {
                 cosAngle = (cosAngle < 0.0) ? -1.0 : 1.0;
                 sinAngle = 0.0;
             }
 
-            if (Math.Abs(cosAngle * cosAngle + sinAngle * sinAngle - 1.0) > GeoSharpMath.MAXTOLERANCE)
+            if (Math.Abs(cosAngle * cosAngle + sinAngle * sinAngle - 1.0) > GeoSharpMath.MAX_TOLERANCE)
             {
                 Vector3 vec = new Vector3 { cosAngle, sinAngle };
                 if (vec.Length() > 0.0)

--- a/src/GShark/Core/Interval.cs
+++ b/src/GShark/Core/Interval.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data.SqlTypes;
 
 namespace GShark.Core
 {
@@ -8,47 +9,72 @@ namespace GShark.Core
     public class Interval
     {
         /// <summary>
-        /// Creates an instance of an interval by the values.
+        /// Creates an instance of an interval given a minimum and a maximum value.
         /// </summary>
-        /// <param name="min">The minimum value of the interval.</param>
-        /// <param name="max">The maximum value of the interval.</param>
-        public Interval(double min, double max)
+        /// <param name="t0"></param>
+        /// <param name="t1"></param>
+        public Interval(double t0, double t1)
         {
-            Min = min;
-            Max = max;
+            T0 = t0;
+            T1 = t1;
         }
 
         /// <summary>
-        /// The minimum value of the interval.
+        /// Gets the minimum value of the interval.
         /// </summary>
-        public double Min { get; }
+        public double T0 { get; }
 
         /// <summary>
-        /// The maximum value of the interval.
+        /// Gets the maximum value of the interval.
         /// </summary>
-        public double Max { get; }
+        public double T1 { get; }
 
         /// <summary>
-        /// Gets the average value.
+        /// Gets the value between the interval's min and max values.
         /// </summary>
-        public double Mid => Math.Abs(Min - Max) > GeoSharpMath.MAXTOLERANCE ? 0.5 * (Min + Max) : Min;
+        public double Mid => Math.Abs(T0 - T1) > GeoSharpMath.MAX_TOLERANCE ? 0.5 * (T0 + T1) : T0;
 
         /// <summary>
-        /// Gets the length of the interval range.<br/>
+        /// Gets the length of the interval.<br/>
         /// If the interval is decreasing, negative number will be returned.
         /// </summary>
-        public double Length => Max - Min;
+        public double Length => Math.Abs(T1 - T0);
+
+        /// <summary>
+        /// True if t0 is less than t1.
+        /// </summary>
+        public bool IsDecreasing => T0 - T1 > 0;
+
+        /// <summary>
+        /// True if t1 is greater than t0.
+        /// </summary>
+        public bool IsIncreasing => T1 - T0 > 0;
+
+        /// <summary>
+        /// True if t0 == t1.
+        /// </summary>
+        public bool IsSingleton => Math.Abs(T1 - T0) >= GeoSharpMath.EPSILON;
+
+        /// <summary>
+        /// Returns the largest value in the interval.
+        /// </summary>
+        public double Max => Math.Max(T1, T0);
+
+        /// <summary>
+        /// Returns the smallest value in the interval.
+        /// </summary>
+        public double Min => Math.Min(T1, T0);
 
         /// <summary>
         /// Converts normalized parameter to interval value, or pair of values.
         /// </summary>
-        /// <param name="normalizedParameter">The normalized parameter between 0-1.</param>
-        /// <returns>Interval parameter min*(1.0-normalizedParameter) + max*normalizedParameter.</returns>
+        /// <param name="normalizedParameter">The normalized parameter between 0 and 1.</param>
+        /// <returns>Interval parameter t0*(1.0-normalizedParameter) + t1*normalizedParameter.</returns>
         public double ParameterAt(double normalizedParameter)
         {
             return !GeoSharpMath.IsValidDouble(normalizedParameter)
-                ? -1.23432101234321E+308
-                : (1.0 - normalizedParameter) * Min + normalizedParameter * Max;
+                ? GeoSharpMath.UNSET_VALUE
+                : (1.0 - normalizedParameter) * T0 + normalizedParameter * T1;
         }
     }
 }

--- a/src/GShark/Core/Interval.cs
+++ b/src/GShark/Core/Interval.cs
@@ -53,7 +53,7 @@ namespace GShark.Core
         /// <summary>
         /// True if t0 == t1.
         /// </summary>
-        public bool IsSingleton => Math.Abs(T1 - T0) >= GeoSharpMath.EPSILON;
+        public bool IsSingleton => Math.Abs(T1 - T0) <= GeoSharpMath.EPSILON;
 
         /// <summary>
         /// Returns the largest value in the interval.

--- a/src/GShark/Core/LinearAlgebra.cs
+++ b/src/GShark/Core/LinearAlgebra.cs
@@ -210,8 +210,8 @@ namespace GShark.Core
         {
             Dictionary<string, double> values = new Dictionary<string, double>();
 
-            if ((Math.Abs(transform[1][0]) < GeoSharpMath.MINTOLERANCE && Math.Abs(transform[0][0]) < GeoSharpMath.MINTOLERANCE) ||
-                (Math.Abs(transform[2][1]) < GeoSharpMath.MINTOLERANCE && Math.Abs(transform[2][2]) < GeoSharpMath.MINTOLERANCE) ||
+            if ((Math.Abs(transform[1][0]) < GeoSharpMath.MIN_TOLERANCE && Math.Abs(transform[0][0]) < GeoSharpMath.MIN_TOLERANCE) ||
+                (Math.Abs(transform[2][1]) < GeoSharpMath.MIN_TOLERANCE && Math.Abs(transform[2][2]) < GeoSharpMath.MIN_TOLERANCE) ||
                 (Math.Abs(transform[2][0]) >= 1.0))
             {
                 values.Add("Pitch" , (transform[2][0] > 0) ? -Math.PI / 2.0 : Math.PI / 2.0);
@@ -237,9 +237,9 @@ namespace GShark.Core
         {
             Vector3 axis = Vector3.Unset;
 
-            if (Math.Abs(transform[0][1] + transform[1][0]) < GeoSharpMath.MINTOLERANCE || 
-                Math.Abs(transform[0][2] + transform[2][0]) < GeoSharpMath.MINTOLERANCE ||
-                Math.Abs(transform[1][2] + transform[2][1]) < GeoSharpMath.MINTOLERANCE)
+            if (Math.Abs(transform[0][1] + transform[1][0]) < GeoSharpMath.MIN_TOLERANCE || 
+                Math.Abs(transform[0][2] + transform[2][0]) < GeoSharpMath.MIN_TOLERANCE ||
+                Math.Abs(transform[1][2] + transform[2][1]) < GeoSharpMath.MIN_TOLERANCE)
             {
                 double xx = (transform[0][0] + 1) / 2;
                 double yy = (transform[1][1] + 1) / 2;
@@ -249,7 +249,7 @@ namespace GShark.Core
                 double yz = (transform[1][2] + transform[2][1]) / 4;
                 if ((xx > yy) && (xx > zz))
                 { // m[0][0] is the largest diagonal term
-                    if (xx < GeoSharpMath.MINTOLERANCE)
+                    if (xx < GeoSharpMath.MIN_TOLERANCE)
                     {
                         axis[0] = 0;
                         axis[1] = 0.7071;
@@ -264,7 +264,7 @@ namespace GShark.Core
                 }
                 else if (yy > zz)
                 { // m[1][1] is the largest diagonal term
-                    if (yy < GeoSharpMath.MINTOLERANCE)
+                    if (yy < GeoSharpMath.MIN_TOLERANCE)
                     {
                         axis[0] = 0.7071;
                         axis[1] = 0;
@@ -279,7 +279,7 @@ namespace GShark.Core
                 }
                 else
                 { // m[2][2] is the largest diagonal term so base result on this
-                    if (zz < GeoSharpMath.MINTOLERANCE)
+                    if (zz < GeoSharpMath.MIN_TOLERANCE)
                     {
                         axis[0] = 0.7071;
                         axis[1] = 0.7071;

--- a/src/GShark/Core/Sets.cs
+++ b/src/GShark/Core/Sets.cs
@@ -33,7 +33,7 @@ namespace GShark.Core
         {
             if (step <= 0)
             {
-                return new List<double>() { domain.Min, domain.Max };
+                return new List<double>() { domain.T0, domain.T1 };
             }
 
             List<double> l = new List<double>();
@@ -58,24 +58,24 @@ namespace GShark.Core
         /// <returns>A collection of equally spaced numbers.</returns>
         public static IList<double> LinearSpace(Interval domain, int step)
         {
-            if(Math.Abs(domain.Min - domain.Max) <= GeoSharpMath.EPSILON)
+            if(Math.Abs(domain.T0 - domain.T1) <= GeoSharpMath.EPSILON)
             {
-                return new List<double>(){ domain.Min };
+                return new List<double>(){ domain.T0 };
             }
 
             List<double> linearSpace = new List<double>();
 
             if (step <= 1)
             {
-                linearSpace.Add(domain.Min);
+                linearSpace.Add(domain.T0);
                 return linearSpace;
             }
 
             int div = step - 1;
-            double delta = domain.Max - domain.Min;
+            double delta = domain.T1 - domain.T0;
             for (int i = 0; i < step; i++)
             {
-                linearSpace.Add(domain.Min + (i * delta / div));
+                linearSpace.Add(domain.T0 + (i * delta / div));
             }
 
             return linearSpace;
@@ -90,7 +90,7 @@ namespace GShark.Core
         {
             if (maxValue <= 0)
             {
-                throw new Exception("Max value range can not be negative or zero.");
+                throw new Exception("T1 value range can not be negative or zero.");
             }
 
             List<double> l = new List<double>();

--- a/src/GShark/Geometry/BoundingBox.cs
+++ b/src/GShark/Geometry/BoundingBox.cs
@@ -88,7 +88,7 @@ namespace GShark.Geometry
         public Vector3 Max { get; }
 
         /// <summary>
-        /// Gets a BoundingBox that has Unset coordinates for Min and Max.
+        /// Gets a BoundingBox that has Unset coordinates for T0 and T1.
         /// </summary>
         public static BoundingBox Unset { get; } = new BoundingBox(Vector3.Unset, Vector3.Unset);
 
@@ -152,7 +152,7 @@ namespace GShark.Geometry
                 return false;
             }
 
-            tol = tol < -0.5 ? GeoSharpMath.MAXTOLERANCE : tol;
+            tol = tol < -0.5 ? GeoSharpMath.MAX_TOLERANCE : tol;
             int count = 0;
             for (int i = 0; i < 3; i++)
             {
@@ -295,7 +295,7 @@ namespace GShark.Geometry
 
         /// <summary>
         /// Ensures that the box is defined in an increasing fashion.
-        /// If the Min or Max points are unset, this function will return a BoundingBox unset.
+        /// If the T0 or T1 points are unset, this function will return a BoundingBox unset.
         /// </summary>
         /// <returns>A BoundingBox made valid.</returns>
         public BoundingBox MakeItValid()

--- a/src/GShark/Geometry/Circle.cs
+++ b/src/GShark/Geometry/Circle.cs
@@ -174,7 +174,7 @@ namespace GShark.Geometry
         public Vector3 ClosestPt(Vector3 pt)
         {
             (double u, double v) = Plane.ClosestParameters(pt);
-            if (Math.Abs(u) < GeoSharpMath.MAXTOLERANCE && Math.Abs(v) < GeoSharpMath.MAXTOLERANCE)
+            if (Math.Abs(u) < GeoSharpMath.MAX_TOLERANCE && Math.Abs(v) < GeoSharpMath.MAX_TOLERANCE)
             {
                 return PointAt(0.0);
             }
@@ -217,7 +217,7 @@ namespace GShark.Geometry
                 return false;
             }
 
-            return Math.Abs(Radius - other.Radius) < GeoSharpMath.MAXTOLERANCE && Plane == other.Plane;
+            return Math.Abs(Radius - other.Radius) < GeoSharpMath.MAX_TOLERANCE && Plane == other.Plane;
         }
 
         /// <summary>

--- a/src/GShark/Geometry/NurbsCurve.cs
+++ b/src/GShark/Geometry/NurbsCurve.cs
@@ -110,7 +110,7 @@ namespace GShark.Geometry
                     Extrema e = Evaluation.ComputeExtrema(crv);
                     foreach (double eValue in e.Values)
                     {
-                        if(eValue == 0.0 || Math.Abs(eValue - 1) < GeoSharpMath.MAXTOLERANCE) continue;
+                        if(eValue == 0.0 || Math.Abs(eValue - 1) < GeoSharpMath.MAX_TOLERANCE) continue;
                         pts.Add(crv.PointAt(eValue));
                     }
                 }

--- a/src/GShark/Geometry/Plane.cs
+++ b/src/GShark/Geometry/Plane.cs
@@ -223,13 +223,13 @@ namespace GShark.Geometry
                 throw new Exception("The points don't span a plane.");
             }
 
-            if (Math.Abs(determinantMax - determinantX) < GeoSharpMath.MAXTOLERANCE)
+            if (Math.Abs(determinantMax - determinantX) < GeoSharpMath.MAX_TOLERANCE)
             {
                 normal[0] = determinantX;
                 normal[1] = xz * yz - xy * zz;
                 normal[2] = xy * yz - xz * yy;
             }
-            else if (Math.Abs(determinantMax - determinantY) < GeoSharpMath.MAXTOLERANCE)
+            else if (Math.Abs(determinantMax - determinantY) < GeoSharpMath.MAX_TOLERANCE)
             {
                 normal[0] = xz * yz - xy * zz;
                 normal[1] = determinantY;
@@ -277,10 +277,10 @@ namespace GShark.Geometry
         {
             Vector3 origin = Origin * transformation;
 
-            bool check = (Math.Abs(transformation[3][0]) <= GeoSharpMath.MAXTOLERANCE &&
-                          Math.Abs(transformation[3][1]) <= GeoSharpMath.MAXTOLERANCE &&
-                          Math.Abs(transformation[3][2]) <= GeoSharpMath.MAXTOLERANCE &&
-                          Math.Abs(1.0 - transformation[3][3]) <= GeoSharpMath.MAXTOLERANCE);
+            bool check = (Math.Abs(transformation[3][0]) <= GeoSharpMath.MAX_TOLERANCE &&
+                          Math.Abs(transformation[3][1]) <= GeoSharpMath.MAX_TOLERANCE &&
+                          Math.Abs(transformation[3][2]) <= GeoSharpMath.MAX_TOLERANCE &&
+                          Math.Abs(1.0 - transformation[3][3]) <= GeoSharpMath.MAX_TOLERANCE);
 
             Vector3 xDir = check ? ((Origin + XAxis) * transformation) - origin : XAxis * transformation;
             Vector3 yDir = check ? ((Origin + YAxis) * transformation) - origin : YAxis * transformation;

--- a/src/GShark/Geometry/Polygon.cs
+++ b/src/GShark/Geometry/Polygon.cs
@@ -22,7 +22,7 @@ namespace GShark.Geometry
 
             Plane fitPlane = Plane.FitPlane(vertices, out double deviation);
 
-            if (!(Math.Abs(deviation) < GeoSharpMath.MINTOLERANCE))
+            if (!(Math.Abs(deviation) < GeoSharpMath.MIN_TOLERANCE))
             {
                 throw new Exception("The points must be co-planar.");
             }
@@ -49,7 +49,7 @@ namespace GShark.Geometry
                 bool isOnPlaneXY = true;
                 Transform transformBack = new Transform();
                 List<Vector3> copiedPts = new List<Vector3>(this);
-                if (Math.Abs(this[0][2]) > GeoSharpMath.MAXTOLERANCE)
+                if (Math.Abs(this[0][2]) > GeoSharpMath.MAX_TOLERANCE)
                 {
                     isOnPlaneXY = false;
                     Plane polygonPlane = new Plane(this[0], this[1], this[2]);

--- a/src/GShark/Geometry/Polyline.cs
+++ b/src/GShark/Geometry/Polyline.cs
@@ -298,7 +298,7 @@ namespace GShark.Geometry
             for (int i = 1; i < vertices.Count; i++)
             {
                 coincidenceFlag[i] = 0;
-                if (vertices[i] == null || vertices[i - 1].DistanceTo(vertices[i]) <= GeoSharpMath.MAXTOLERANCE)
+                if (vertices[i] == null || vertices[i - 1].DistanceTo(vertices[i]) <= GeoSharpMath.MAX_TOLERANCE)
                 {
                     coincidenceFlag[i] = 1;
                 }

--- a/src/GShark/Geometry/Vector3.cs
+++ b/src/GShark/Geometry/Vector3.cs
@@ -32,10 +32,10 @@ namespace GShark.Geometry
         }
 
         /// <summary>
-        /// Gets the value of a point at location GeoSharpMath.UNSETVALUE,GeoSharpMath.UNSETVALUE,GeoSharpMath.UNSETVALUE.
+        /// Gets the value of a point at location GeoSharpMath.UNSET_VALUE,GeoSharpMath.UNSET_VALUE,GeoSharpMath.UNSET_VALUE.
         /// </summary>
         public static Vector3 Unset => new Vector3
-            {GeoSharpMath.UNSETVALUE, GeoSharpMath.UNSETVALUE, GeoSharpMath.UNSETVALUE};
+            {GeoSharpMath.UNSET_VALUE, GeoSharpMath.UNSET_VALUE, GeoSharpMath.UNSET_VALUE};
 
         /// <summary>
         /// Gets the value of the vector with components 1,0,0.
@@ -155,7 +155,7 @@ namespace GShark.Geometry
         public bool IsPerpendicularTo(Vector3 other, double tolerance = -1)
         {
             bool result = false;
-            double toleranceSet = (tolerance < 0) ? GeoSharpMath.ANGLETOLERANCE : tolerance;
+            double toleranceSet = (tolerance < 0) ? GeoSharpMath.ANGLE_TOLERANCE : tolerance;
             double length = this.Length() * other.Length();
             double dotUnitize = Vector3.Dot(this, other) / length;
             if (length > 0 && dotUnitize <= Math.Sin(toleranceSet)) result = true;
@@ -174,7 +174,7 @@ namespace GShark.Geometry
         public int IsParallelTo(Vector3 other, double tolerance = -1)
         {
             int result = 0;
-            double toleranceSet = (tolerance < 0) ? Math.Cos(GeoSharpMath.ANGLETOLERANCE) : Math.Cos(tolerance);
+            double toleranceSet = (tolerance < 0) ? Math.Cos(GeoSharpMath.ANGLE_TOLERANCE) : Math.Cos(tolerance);
             double length = this.Length() * other.Length();
             double dotUnitize = Vector3.Dot(this, other) / length;
             if (!(length > 0)) return result;

--- a/src/GShark/Operation/Analyze.cs
+++ b/src/GShark/Operation/Analyze.cs
@@ -164,7 +164,7 @@ namespace GShark.Operation
             int maxInteraction = 5;
             int j = 0;
             // Two zero tolerances can be used to indicate convergence:
-            double tol1 = GeoSharpMath.MAXTOLERANCE; // a measure of Euclidean distance;
+            double tol1 = GeoSharpMath.MAX_TOLERANCE; // a measure of Euclidean distance;
             double tol2 = 0.0005; // a zero cosine measure.
             double tVal0 = curve.Knots[0];
             double tVal1 = curve.Knots[^1];

--- a/src/GShark/Operation/Divide.cs
+++ b/src/GShark/Operation/Divide.cs
@@ -85,7 +85,7 @@ namespace GShark.Operation
                 while (segmentLength < sum + GeoSharpMath.EPSILON)
                 {
                     double t = Analyze.BezierCurveParamAtLength(curves[i], segmentLength - sum2,
-                        GeoSharpMath.MAXTOLERANCE, curveLengths[i]);
+                        GeoSharpMath.MAX_TOLERANCE, curveLengths[i]);
 
                     tValues.Add(t);
                     divisionLengths.Add(segmentLength);

--- a/src/GShark/Operation/Evaluation.cs
+++ b/src/GShark/Operation/Evaluation.cs
@@ -282,6 +282,7 @@ namespace GShark.Operation
                 }
 
                 result = result.Where((t) => t >= 0 && t <= 1).ToList();
+                //ToDo result is a collection of doubles, t, therefore the comparison for Sort should be implicit using standard sorting methods in LINQ.
                 result.Sort(GeoSharpMath.NumberSort);
                 extrema[j] = result;
             }

--- a/src/GShark/Operation/Intersect.cs
+++ b/src/GShark/Operation/Intersect.cs
@@ -241,12 +241,12 @@ namespace GShark.Operation
             double det = b * b - 4 * a * c;
             double t;
 
-            if ((a <= GeoSharpMath.MAXTOLERANCE) || (det < 0))
+            if ((a <= GeoSharpMath.MAX_TOLERANCE) || (det < 0))
             {
                 pts = new Vector3[] { };
                 return false;
             }
-            else if (Math.Abs(det) < GeoSharpMath.MAXTOLERANCE)
+            else if (Math.Abs(det) < GeoSharpMath.MAX_TOLERANCE)
             {
                 t = -b / (2 * a);
                 Vector3 intersection = pt0 + lnDir * t;

--- a/src/GShark/Operation/Tessellation.cs
+++ b/src/GShark/Operation/Tessellation.cs
@@ -73,11 +73,11 @@ namespace GShark.Operation
         /// <param name="start">The start parameter for sampling.</param>
         /// <param name="end">The end parameter for sampling.</param>
         /// <param name="tolerance">Tolerance for the adaptive scheme.
-        /// If tolerance is smaller or equal 0.0, the tolerance used is set as MAXTOLERANCE (1e-6).</param>
+        /// If tolerance is smaller or equal 0.0, the tolerance used is set as MAX_TOLERANCE (1e-6).</param>
         /// <returns>A tuple with the set of points and the t parameter where the point was evaluated.</returns>
         public static (List<double> tValues, List<Vector3> pts) CurveAdaptiveSampleRange(ICurve curve, double start, double end, double tolerance)
         {
-            double setTolerance = (tolerance <= 0.0) ? GeoSharpMath.MAXTOLERANCE : tolerance;
+            double setTolerance = (tolerance <= 0.0) ? GeoSharpMath.MAX_TOLERANCE : tolerance;
 
             // Sample curve at three pts.
             Random random = new Random();

--- a/src/GShark/Optimization/Minimizer.cs
+++ b/src/GShark/Optimization/Minimizer.cs
@@ -102,7 +102,7 @@ namespace GShark.Optimization
                 }
                 if (iteration > maxIteration)
                 {
-                    message = "Max iteration reached during line search.";
+                    message = "T1 iteration reached during line search.";
                     break;
                 }
 


### PR DESCRIPTION
- Refactored Interval class so as to have t0 and t1 as start and end values, and separating them from min and max values. This is because a decreasing interval [0.5, -3] would report the Min value as 0.5 when in fact it is -3. Without validating whether the ctor params are in the correct order (i.e. enforcing of increasing interval) you may return wrong values. It aligns closely with rhinocommon's implementation and provides additional properties.
- Cleaned up some typos and formatted some minor parts to comply with MS coding style. 
- Added ToDo's for consideration. 